### PR TITLE
Add a Special User Mode

### DIFF
--- a/redact_changeset.rb
+++ b/redact_changeset.rb
@@ -126,7 +126,7 @@ EOF
 
   def write_redact_command(klass, elt_id, version, fp)
     name = get_object_type_as_name(klass)
-    fp.puts "perl redaction.pl #{elt_id} #{name} #{version}\n"
+    fp.puts "perl redaction.pl apply #{name} #{elt_id} #{version}\n"
   end
 
   def redact(klass, elt_id, version, red_id)


### PR DESCRIPTION
This pull request adds a mode I call "user mode". The redaction ID is 0 in this mode and no redactions (only reverts) are done. As an replacement, redact_changeset.rb writes a script which calls woodpeck's [redaction.pl](https://github.com/woodpeck/osm-revert-scripts/blob/master/redaction.pl) script.

In some cases you do not want to redact changes (or you lack the permissions) because their license is ok but you want to revert them. Reverts are difficult if later changes have been applied to the edited objects (you get conflicts). If you can solve the conflicts automatically (has some downsides), you can revert them easier. The script calling redaction.pl which is written as an output, can be used by a DWG member to redact the old versions later if the need to redact them arises.

I act resposibly. Therefor, I am still doing manual tests on the Dev API (my accounts are Nakaner-repair-dev and Nakaner-dev) before I will use redact_changeset.pl on the live database. This pull request just proposes a merge of the improvements I have done yet.