### PR TITLE
Update to use SSL

### DIFF
--- a/redact_changeset.rb
+++ b/redact_changeset.rb
@@ -143,6 +143,7 @@ EOF
         uri = URI("#{@server}/api/0.6/#{path}")
         puts "GET: #{uri}"
         http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
         http.read_timeout = 320
         
         response = http.request_get(uri.request_uri)


### PR DESCRIPTION
OSM servers are now using HTTPS.
Otherwise when using an `https:` URL we would get this:

```
GET: https://master.apis.dev.openstreetmap.org/api/0.6/changeset/X/download
Got exception: FAIL: https://master.apis.dev.openstreetmap.org/api/0.6/changeset/X/download => 400:
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
---
<html><head>
<title>400 Bad Request</title>
</head><body>
<h1>Bad Request</h1>
<p>Your browser sent a request that this server could not understand.<br />
Reason: You're speaking plain HTTP to an SSL-enabled server port.<br />
 Instead use the HTTPS scheme to access this URL, please.<br />
</p>
```
Or, when using an `http` URL the script won't follow the redirect:

```
GET: http://master.apis.dev.openstreetmap.org/api/0.6/changeset/X/download
Got exception: FAIL: http://master.apis.dev.openstreetmap.org/api/0.6/changeset/X/download => 301:
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://master.apis.dev.openstreetmap.org/api/0.6/changeset/X/download">here</a>.</p>
<hr>
```