### PR TITLE
Increase the max number of objects per changeset

### DIFF
--- a/redact_changeset.rb
+++ b/redact_changeset.rb
@@ -13,7 +13,7 @@ require 'yaml'
 require 'optparse'
 require 'typhoeus'
 
-MAX_CHANGESET_ELEMENTS = 500
+MAX_CHANGESET_ELEMENTS = 1000
 
 class Server
   def initialize(file, dry_run)


### PR DESCRIPTION
500 objects per changeset seems (and feels) too much conservative.
1000 is slight better and is still 10% of the current API max (10000)