### PR TITLE
Close the changeset after a successful upload

### DIFF
--- a/redact_changeset.rb
+++ b/redact_changeset.rb
@@ -102,7 +102,13 @@ EOF
       tries = 0
       loop do
         response = @access_token.post("/api/0.6/changeset/#{changeset_id}/upload", change_doc, {'Content-Type' => 'text/xml' })
-        break if response.code == '200'
+        if response.code == '200'
+          # Just try once to close the changeset and simply ignore any
+          # possible errors; If we could not close it, it will be
+          # automatically closed after some time
+          @access_token.put("/api/0.6/changeset/#{changeset_id}/close")
+          break
+        end
         tries += 1
         if tries >= @max_retries
           # It's quite likely for a changeset to fail, if someone else is editing in the area being processed


### PR DESCRIPTION
Treat this as a proof of concept, if necessary.
If we take a look at https://master.apis.dev.openstreetmap.org/api/0.6/changeset/126867 (which was a redaction of a single node for testing purposes) it's possible to see that `redact_changeset.rb` isn't closing the changeset after reverting something:

`created_at="2018-07-28T18:42:44Z" closed_at="2018-07-28T19:42:46Z"`

ie, it was [automatically closed after 1 hour](https://wiki.openstreetmap.org/wiki/API_v0.6#Changesets_2).

By properly closing the changeset after a successful upload we allow people to interact (leaving a changeset comment) more quickly, if needed.